### PR TITLE
Large Maps!

### DIFF
--- a/.fusion_assets/fusionTools_largeSlideMap.js
+++ b/.fusion_assets/fusionTools_largeSlideMap.js
@@ -1,0 +1,152 @@
+window.fusionTools = Object.assign({}, window.fusionTools, {
+    largeSlideMap: {
+        centerMap: function(e, ctx) {
+            ctx.map.flyTo([-120, 120], 1);
+        },
+        featureStyle: function(feature, context) {
+                var {
+                    overlayBounds,
+                    overlayProp,
+                    fillOpacity,
+                    lineColor,
+                    filterVals,
+                    lineWidth,
+                    colorMap
+                } = context.hideout;
+                var style = {};
+                if (Object.keys(chroma.brewer).includes(colorMap)) {
+                    colorMap = colorMap;
+                } else {
+                    colorMap = colorMap.split("->");
+                }
+
+                if ("min" in overlayBounds) {
+                    var csc = chroma.scale(colorMap).domain([overlayBounds.min, overlayBounds.max]);
+                } else if ("unique" in overlayBounds) {
+                    var class_indices = overlayBounds.unique.map(str => overlayBounds.unique.indexOf(str));
+                    var csc = chroma.scale(colorMap).colors(class_indices.length);
+                } else {
+                    style.fillColor = 'white';
+                    style.fillOpacity = fillOpacity;
+                    if ('name' in feature.properties) {
+                        style.color = lineColor[feature.properties.name];
+                    } else {
+                        style.color = 'white';
+                    }
+
+                    return style;
+                }
+
+                var overlayVal = Number.Nan;
+                if (overlayProp) {
+                    if (overlayProp.name) {
+                        //TODO: Update this for different types of nested props (--+ = list, --# = external reference object)
+                        var overlaySubProps = overlayProp.name.split(" --> ");
+                        var prop_dict = feature.properties;
+                        for (let i = 0; i < overlaySubProps.length; i++) {
+                            if (prop_dict == prop_dict && prop_dict != null && typeof prop_dict === 'object') {
+                                if (overlaySubProps[i] in prop_dict) {
+                                    var prop_dict = prop_dict[overlaySubProps[i]];
+                                    var overlayVal = prop_dict;
+                                } else {
+                                    prop_dict = Number.Nan;
+                                    var overlayVal = Number.Nan;
+                                }
+                            }
+                        }
+                    } else {
+                        var overlayVal = Number.Nan;
+                    }
+                } else {
+                    var overlayVal = Number.Nan;
+                }
+
+                if (overlayVal == overlayVal && overlayVal != null) {
+                    if (typeof overlayVal === 'number') {
+                        style.fillColor = csc(overlayVal);
+                    } else if ('unique' in overlayBounds) {
+                        overlayVal = overlayBounds.unique.indexOf(overlayVal);
+                        style.fillColor = csc[overlayVal];
+                    } else {
+                        style.fillColor = "f00";
+                    }
+                } else {
+                    style.fillColor = "f00";
+                }
+
+                style.fillOpacity = fillOpacity;
+                if (feature.properties.name in lineColor) {
+                    style.color = lineColor[feature.properties.name];
+                } else {
+                    style.color = 'white';
+                }
+
+                return style;
+            }
+
+            ,
+        featureFilter: function(feature, context) {
+                const {
+                    overlayBounds,
+                    overlayProp,
+                    fillOpacity,
+                    lineColor,
+                    filterVals,
+                    lineWidth,
+                    colorMap
+                } = context.hideout;
+
+                var returnFeature = true;
+                if (filterVals) {
+                    for (let i = 0; i < filterVals.length; i++) {
+                        // Iterating through filterVals list
+                        var filter = filterVals[i];
+                        if (filter.name) {
+                            //TODO: Update this for different types of nested props (--+ = list, --# = external reference object)
+                            var filterSubProps = filter.name.split(" --> ");
+                            var prop_dict = feature.properties;
+                            for (let j = 0; j < filterSubProps.length; j++) {
+                                if (prop_dict == prop_dict && prop_dict != null && typeof prop_dict === 'object') {
+                                    if (filterSubProps[j] in prop_dict) {
+                                        var prop_dict = prop_dict[filterSubProps[j]];
+                                        var testVal = prop_dict;
+                                    } else {
+                                        prop_dict = Number.Nan;
+                                        returnFeature = returnFeature & false;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (filter.range && returnFeature) {
+                            if (typeof filter.range[0] === 'number') {
+                                if (testVal < filter.range[0]) {
+                                    returnFeature = returnFeature & false;
+                                }
+                                if (testVal > filter.range[1]) {
+                                    returnFeature = returnFeature & false;
+                                }
+                            } else {
+                                if (filter.range.includes(testVal)) {
+                                    returnFeature = returnFeature & true;
+                                } else {
+                                    returnFeature = returnFeature & false;
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    return returnFeature;
+                }
+                return returnFeature;
+            }
+
+            ,
+        sendPosition: function(e, ctx) {
+            ctx.setProps({
+                data: e.latlng
+            });
+        }
+
+    }
+});

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="fusion-tools",
-    version="3.0.4",
+    version="3.0.6",
     author="Sam Border",
     author_email="sam.border2256@gmail.com",
     description="Modular visualization and analysis dashboard creation for high-resolution microscopy images",

--- a/src/fusion_tools.egg-info/PKG-INFO
+++ b/src/fusion_tools.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.2
 Name: fusion-tools
-Version: 3.0.4
+Version: 3.0.6
 Summary: Modular visualization and analysis dashboard creation for high-resolution microscopy images
 Home-page: https://github.com/spborder/fusion-tools
 Author: Sam Border

--- a/src/fusion_tools/components/maps.py
+++ b/src/fusion_tools/components/maps.py
@@ -1439,6 +1439,12 @@ class MultiFrameSlideMap(SlideMap):
                             'click': self.js_namespace('centerMap')
                         }
                     ),
+                    dl.EasyButton(
+                        icon = 'fa-solid fa-upload',
+                        title = 'Upload Shapes',
+                        id = {'type': 'upload-shape','index': 0},
+                        position = 'top-left'
+                    ),
                     html.Div(
                         id = {'type': 'map-marker-div','index': 0},
                         children = []
@@ -1571,6 +1577,58 @@ class MultiFrameSlideMap(SlideMap):
             raise TypeError("Missing 'frames' key in image metadata")
         
         return frame_layers
+
+
+class LargeSlideMap(SlideMap):
+    """This is a subclass of SlideMap used for LARGE amounts of annotations (>50k)
+
+    :param SlideMap: _description_
+    :type SlideMap: _type_
+    """
+    def __init__(self,
+                 max_load:int,
+                 max_zoom:int,
+                 ):
+        super().__init__()
+
+        self.max_load = max_load
+        self.max_zoom = max_zoom
+
+    def __str__(self):
+        return "Large Slide Map"
+    
+    def get_namespace(self):
+        pass
+
+    def update_layout(self, session_data:dict, use_prefix:bool):
+        pass
+    
+
+class LargeMultiFrameSlideMap(MultiFrameSlideMap):
+    """This is a sub-class of MultiFrameSlideMap used for LARGE amounts of annotations (>50k)
+
+    :param MultiFrameSlideMap: _description_
+    :type MultiFrameSlideMap: _type_
+    """
+    def __init__(self,
+                 max_load:int,
+                 max_zoom:int):
+        
+        super().__init__()
+        self.max_load = max_load
+        self.max_zoom = max_zoom
+
+    def __str__(self):
+        return "Large Multi Frame Slide Map"
+
+    def get_namespace(self):
+        pass
+
+    def update_layout(self, session_data:dict, use_prefix:bool):
+        pass
+    
+
+
 
 
 class SlideImageOverlay(MapComponent):

--- a/src/fusion_tools/components/maps.py
+++ b/src/fusion_tools/components/maps.py
@@ -31,7 +31,7 @@ from dash_extensions.enrich import DashBlueprint, html, Input, Output, State, Mu
 from dash_extensions.javascript import assign, arrow_function, Namespace
 
 # fusion-tools imports
-from fusion_tools.utils.shapes import find_intersecting, spatially_aggregate, convert_histomics
+from fusion_tools.utils.shapes import find_intersecting, spatially_aggregate, convert_histomics, detect_image_overlay
 from fusion_tools.visualization.vis_utils import get_pattern_matching_value
 
 
@@ -58,9 +58,7 @@ class SlideMap(MapComponent):
     def __init__(self):
         """Constructor method
         """
-
-        # Property referring to how the layout is updated with a change in the visualization session
-        self.session_update = True
+        super().__init__()
 
         # Add Namespace functions here:
         self.assets_folder = os.getcwd()+'/.fusion_assets/'
@@ -743,7 +741,7 @@ class SlideMap(MapComponent):
                             ]
                         )
                     ),
-                    name = name, checked = True, id = {'type':f'{self.component_prefix}-feature-overlay','index':st_idx}
+                    name = name, checked = True, id = {'type':f'{self.component_prefix}-feature-overlay','index':np.random.randint(0,1000)}
                 )
             )
         
@@ -1586,23 +1584,658 @@ class LargeSlideMap(SlideMap):
     :type SlideMap: _type_
     """
     def __init__(self,
-                 max_load:int,
-                 max_zoom:int,
+                 min_zoom:int,
                  ):
         super().__init__()
 
-        self.max_load = max_load
-        self.max_zoom = max_zoom
+        self.min_zoom = min_zoom
+
+    def load(self,component_prefix:int):
+
+        self.component_prefix = component_prefix
+
+        self.title = 'Large Slide Map'
+        self.blueprint = DashBlueprint(
+            transforms = [
+                PrefixIdTransform(prefix = f'{self.component_prefix}'),
+                MultiplexerTransform()
+            ]
+        )
+
+        self.get_callbacks()
+
+        self.large_map_callbacks()
 
     def __str__(self):
         return "Large Slide Map"
     
-    def get_namespace(self):
-        pass
-
     def update_layout(self, session_data:dict, use_prefix:bool):
-        pass
+        """Generating LargeSlideMap layout
+
+        :return: Div object containing interactive components for the LargeSlideMap object.
+        :rtype: dash.html.Div.Div
+        """
+
+        layout = html.Div([
+            dcc.Dropdown(
+                id = {'type': 'slide-select-drop','index': 0},
+                placeholder = 'Select a slide to view',
+                options = [
+                    {'label': i['name'],'value': idx}
+                    for idx,i in enumerate(session_data['current'])
+                ],
+                value = [],
+                multi = False,
+                style = {'marginBottom': '10px'}
+            ),
+            html.Div(
+                dcc.Store(
+                    id = {'type': 'map-slide-information','index': 0},
+                    storage_type='memory',
+                    data = json.dumps({})
+                )
+            ),
+            html.Hr(),
+            dl.Map(
+                id = {'type': 'slide-map','index': 0},
+                crs = 'Simple',
+                center = [-120,120],
+                zoom = 0,
+                zoomDelta = 0.25,
+                style = {'height': '90vh','width': '100%','margin': 'auto','display': 'inline-block'},
+                children = [
+                    html.Div(
+                        id = {'type': 'map-tile-layer-holder','index': 0},
+                        children = [
+                            dl.TileLayer(
+                                id = {'type': 'map-tile-layer','index': 0},
+                                url = '',
+                                tileSize=240,
+                                maxNativeZoom=5,
+                                minZoom = 0
+                            )
+                        ]
+                    ),
+                    dl.FullScreenControl(
+                        position = 'upper-left'
+                    ),
+                    dl.FeatureGroup(
+                        id = {'type': 'edit-feature-group','index': 0},
+                        children = [
+                            dl.EditControl(
+                                id = {'type': 'edit-control','index': 0},
+                                draw = dict(polyline=False, line=False, circle = False, circlemarker=False, marker = False),
+                                position='topleft'
+                            )
+                        ]
+                    ),
+                    html.Div(
+                        id = {'type': 'map-colorbar-div','index': 0},
+                        children = []
+                    ),
+                    html.Div(
+                        dcc.Store(
+                            id = {'type': 'map-annotations-store','index': 0},
+                            data = json.dumps({}),
+                            storage_type = 'memory'
+                        )
+                    ),
+                    dl.LayersControl(
+                        id = {'type': 'map-layers-control','index': 0},
+                        children = [
+                            html.Div(
+                                id = {'type': 'map-initial-annotations','index': 0},
+                                children = []
+                            ),
+                            html.Div(
+                                id = {'type': 'map-manual-rois','index': 0},
+                                children = []
+                            ),
+                            html.Div(
+                                id = {'type': 'map-generated-rois','index': 0},
+                                children = []
+                            )
+                        ]
+                    ),
+                    dl.EasyButton(
+                        icon = 'fa-solid fa-arrows-to-dot',
+                        title = 'Re-Center Map',
+                        id = {'type': 'center-map','index': 0},
+                        position = 'top-left',
+                        eventHandlers = {
+                            'click': self.js_namespace('centerMap')
+                        }
+                    ),
+                    dl.EasyButton(
+                        icon = 'fa-solid fa-upload',
+                        title = 'Upload Shapes',
+                        id = {'type': 'upload-shape','index': 0},
+                        position = 'top-left'
+                    ),
+                    html.Div(
+                        id = {'type': 'map-marker-div','index': 0},
+                        children = []
+                    ),
+                ]
+            ),
+            html.Div(
+                id = {'type': 'map-large-options-div','index': 0},
+                children = []
+            ),
+            dbc.Modal(
+                id = {'type': 'upload-shape-modal','index': 0},
+                is_open = False,
+                children = [
+                    html.Div(
+                        dcc.Upload(
+                            children = [
+                                'Drag and Drop or ',
+                                html.A('Select a File')
+                            ], 
+                            id = {'type': 'upload-shape-data','index': 0},
+                            style={'width': '100%','height': '60px','lineHeight': '60px','borderWidth': '1px','borderStyle': 'dashed','borderRadius': '5px','textAlign': 'center'}
+                        )
+                    )
+                ]
+            ),
+            dbc.Modal(
+                id = {'type': 'load-annotations-modal','index': 0},
+                is_open = False,
+                children = []
+            )
+        ])
+
+        if use_prefix:
+            PrefixIdTransform(prefix = self.component_prefix).transform_layout(layout)
+
+        return layout
+
+    def gen_layout(self, session_data: dict):
+
+        self.blueprint.layout = self.update_layout(session_data, use_prefix = False)
+
+    def get_namespace(self):
+
+        self.js_namespace = Namespace(
+            "fusionTools","largeSlideMap"
+        )
+
+        self.js_namespace.add(
+            src = 'function(e,ctx){ctx.map.flyTo([-120,120],1);}',
+            name = "centerMap"
+        )
+
+        self.js_namespace.add(
+            src = """
+                function(feature,context){
+                var {overlayBounds, overlayProp, fillOpacity, lineColor, filterVals, lineWidth, colorMap} = context.hideout;
+                var style = {};
+                if (Object.keys(chroma.brewer).includes(colorMap)){
+                    colorMap = colorMap;
+                } else {
+                    colorMap = colorMap.split("->");
+                }
+
+                if ("min" in overlayBounds) {
+                    var csc = chroma.scale(colorMap).domain([overlayBounds.min,overlayBounds.max]);
+                } else if ("unique" in overlayBounds) {
+                    var class_indices = overlayBounds.unique.map(str => overlayBounds.unique.indexOf(str));
+                    var csc = chroma.scale(colorMap).colors(class_indices.length);
+                } else {
+                    style.fillColor = 'white';
+                    style.fillOpacity = fillOpacity;
+                    if ('name' in feature.properties) {
+                        style.color = lineColor[feature.properties.name];
+                    } else {
+                        style.color = 'white';
+                    }
+
+                    return style;
+                }
+
+                var overlayVal = Number.Nan;
+                if (overlayProp) {
+                    if (overlayProp.name) {
+                        //TODO: Update this for different types of nested props (--+ = list, --# = external reference object)
+                        var overlaySubProps = overlayProp.name.split(" --> ");
+                        var prop_dict = feature.properties;
+                        for (let i = 0; i < overlaySubProps.length; i++) {
+                            if (prop_dict==prop_dict && prop_dict!=null && typeof prop_dict === 'object') {
+                                if (overlaySubProps[i] in prop_dict) {
+                                    var prop_dict = prop_dict[overlaySubProps[i]];
+                                    var overlayVal = prop_dict;
+                                } else {
+                                    prop_dict = Number.Nan;
+                                    var overlayVal = Number.Nan;
+                                }
+                            }
+                        }
+                    } else {
+                        var overlayVal = Number.Nan;
+                    }
+                } else {
+                    var overlayVal = Number.Nan;
+                }
+
+                if (overlayVal==overlayVal && overlayVal!=null) {
+                    if (typeof overlayVal==='number') {
+                        style.fillColor = csc(overlayVal);
+                    } else if ('unique' in overlayBounds) {
+                        overlayVal = overlayBounds.unique.indexOf(overlayVal);
+                        style.fillColor = csc[overlayVal];
+                    } else {
+                        style.fillColor = "f00";
+                    }
+                } else {
+                    style.fillColor = "f00";
+                }
+
+                style.fillOpacity = fillOpacity;
+                if (feature.properties.name in lineColor) {
+                    style.color = lineColor[feature.properties.name];
+                } else {
+                    style.color = 'white';
+                }
+
+                return style;
+                }
+                """,
+            name = 'featureStyle'
+        )
+
+        self.js_namespace.add(
+            src = """
+                function(feature,context){
+                const {overlayBounds, overlayProp, fillOpacity, lineColor, filterVals, lineWidth, colorMap} = context.hideout;
+
+                var returnFeature = true;
+                if (filterVals) {
+                    for (let i = 0; i < filterVals.length; i++) {
+                        // Iterating through filterVals list
+                        var filter = filterVals[i];
+                        if (filter.name) {
+                            //TODO: Update this for different types of nested props (--+ = list, --# = external reference object)
+                            var filterSubProps = filter.name.split(" --> ");
+                            var prop_dict = feature.properties;
+                            for (let j = 0; j < filterSubProps.length; j++) {
+                                if (prop_dict==prop_dict && prop_dict!=null && typeof prop_dict==='object') {
+                                    if (filterSubProps[j] in prop_dict) {
+                                        var prop_dict = prop_dict[filterSubProps[j]];
+                                        var testVal = prop_dict;
+                                    } else {
+                                        prop_dict = Number.Nan;
+                                        returnFeature = returnFeature & false;
+                                    }
+                                }
+                            }
+                        }
+                            
+                        if (filter.range && returnFeature) {
+                            if (typeof filter.range[0]==='number') {
+                                if (testVal < filter.range[0]) {
+                                    returnFeature = returnFeature & false;
+                                }
+                                if (testVal > filter.range[1]) {
+                                    returnFeature = returnFeature & false;
+                                }
+                            } else {
+                                if (filter.range.includes(testVal)) {
+                                    returnFeature = returnFeature & true;
+                                } else {
+                                    returnFeature = returnFeature & false;
+                                }
+                            }
+                        }
+                    }
+                }  else {
+                    return returnFeature;
+                }              
+                return returnFeature;
+                }
+                """,
+            name = 'featureFilter'
+        )
+
+        self.js_namespace.add(
+            src = """
+            function(e,ctx){
+                ctx.setProps({
+                    data: e.latlng
+                });
+            }
+            """,
+            name = 'sendPosition'
+        )
+
+        self.js_namespace.dump(
+            assets_folder = self.assets_folder
+        )
+
+    def large_map_callbacks(self):
+
+        self.blueprint.clientside_callback(
+            """
+            async function(map_bounds,slide_information,current_zoom){
+                // Prevent Update at initialization
+                if (slide_information[0]==undefined){
+                    throw window.dash_clientside.PreventUpdate;
+                } else if (current_zoom[0]==undefined){
+                    throw window.dash_clientside.PreventUpdate;
+                }
+
+                // Run annotation region request, return annotations within that region
+                // Reading in map-slide-information
+                var map_slide_information = JSON.parse(slide_information);
+                var scaled_map_bounds = [
+                    Math.floor(map_bounds[0][1][0] / map_slide_information.y_scale),
+                    Math.floor(map_bounds[0][0][1] / map_slide_information.x_scale),
+                    Math.floor(map_bounds[0][0][0] / map_slide_information.y_scale),
+                    Math.floor(map_bounds[0][1][1] / map_slide_information.x_scale)
+                ];
+
+                // Checking if the maps current zoom level is above the minimum zoom setting
+                if (current_zoom[0] < map_slide_information.minZoom){
+                    throw window.dash_clientside.PreventUpdate;
+                }
+                
+                // This is for DSA slides, annotations are only accessible for regions on an individual basis
+                // and then must be converted to GeoJSON.
+                var annotations_list = [];
+                var annotations_str = [];
+                if ("api_url" in map_slide_information.slide_info){
+                    for (let ann = 0; ann<map_slide_information.annotations_metadata.length; ann++) {
+                        var annotation = map_slide_information.annotations_metadata[ann];
+
+                        try {
+                            let ann_url = map_slide_information.annotations_region_url + annotation._id+"?top="+scaled_map_bounds[0]+"&left="+scaled_map_bounds[1]+"&bottom="+scaled_map_bounds[2]+"&right="+scaled_map_bounds[3]
+                            var ann_response = await fetch(
+                                ann_url, {
+                                method: 'GET',
+                                headers: {
+                                    'Content-Type': 'application/json'    
+                                }
+                            });
+
+                            if (!ann_response.ok) {
+                                throw new Error(`Oh no! Error encountered: ${ann_response.status}`)
+                            }
+
+                            // Scaling coordinates of returned annotations
+                            var new_annotations = await ann_response.json();
+                            let new_geojson = {
+                                "type": "FeatureCollection",
+                                "features": [],
+                                "properties": {
+                                    "name": annotation.annotation.name,
+                                    "_id": annotation._id
+                                }
+                            };
+                            for (let i = 0; i<new_annotations.annotation.elements.length; i++){
+                                let new_feature = {
+                                    "type": "Feature",
+                                    "properties": new_annotations.annotation.elements[i].user,
+                                    "geometry": {
+                                        "type": "Polygon",
+                                        "coordinates": [[]]
+                                    }
+                                };
+
+                                new_feature["properties"]["id"] = i;
+                                new_feature["properties"]["cluster"] = false;
+
+                                for (let j = 0; j<new_annotations.annotation.elements[i].points.length;j++){
+                                    let these_coords = new_annotations.annotation.elements[i].points[j];
+                                    new_feature.geometry.coordinates[0].push([these_coords[0] * map_slide_information.x_scale, these_coords[1] * map_slide_information.y_scale]);
+                                }
+                                new_geojson.features.push(new_feature);
+                            }
+
+                            annotations_str.push(new_geojson);
+                            annotations_list.push(new_geojson);
+                        } catch (error) {
+                            console.error(error.message);
+                        }
+                    }
+                } else {
+                    // General case.
+                    try {
+                        let ann_url = map_slide_information.annotations_region_url+"?top="+scaled_map_bounds[0]+"&left="+scaled_map_bounds[1]+"&bottom="+scaled_map_bounds[2]+"&right="+scaled_map_bounds[3]
+                        var ann_response = await fetch(
+                            ann_url, {
+                            method: 'GET',
+                            headers: {
+                                'Content-Type': 'application/json'    
+                            }
+                        });
+
+                        if (!ann_response.ok) {
+                            throw new Error(`Oh no! Error encountered: ${ann_response.status}`)
+                        }
+
+                        // Scaling coordinates of returned annotations
+                        var new_annotations = await ann_response.json();
+                        // Thanks Suhas
+                        const scale_geoJSON = (data, name, id, x_scale, y_scale) => {
+                            return {
+                                ...data,
+                                properties: {
+                                    name: name,
+                                    _id: id
+                                },
+                                features: data.features.map(feature => ({
+                                    ...feature,
+                                    geometry: {
+                                        ...feature.geometry,
+                                        coordinates: feature.geometry.coordinates.map(axes => 
+                                            axes.map(([x, y]) => [x * x_scale, y * y_scale])
+                                        )
+                                    }
+                                }))
+                            }
+                        }
+
+                        for (let ann=0; ann<new_annotations.length; ann++){
+                            let annotation = map_slide_information.annotations_metadata[ann];
+                            let new_geojson = scale_geoJSON(new_annotations[ann], annotation.name, annotation._id, map_slide_information.x_scale, map_slide_information.y_scale);
+                            
+                            annotations_str.push(new_geojson);
+                            annotations_list.push(new_geojson);
+                        }
+
+                    } catch (error) {
+                        console.error(error.message);
+                    }                
+                }
+
+                return [annotations_list, [JSON.stringify(annotations_str)]];
+            }
+            """,
+            [
+                Output({'type': 'feature-bounds','index': ALL},'data'),
+                Output({'type': 'map-annotations-store','index':ALL},'data')
+            ],
+            Input({'type': 'slide-map','index': ALL},'bounds'),
+            [
+                State({'type':'map-slide-information','index': ALL},'data'),
+                State({'type': 'slide-map','index': ALL},'zoom')
+            ],
+            prevent_initial_call = True
+        )
+
+    def update_slide(self, slide_selected, vis_data):
+        
+        if not any([i['value'] or i['value']==0 for i in ctx.triggered]):
+            raise exceptions.PreventUpdate
+
+        vis_data = json.loads(vis_data)
+        new_slide = vis_data['current'][get_pattern_matching_value(slide_selected)]
+
+        # Getting data from the tileservers:
+        if not 'current_user' in vis_data or not 'api_url' in new_slide:
+            new_tile_url = new_slide['tiles_url']
+            new_annotations_url = new_slide['annotations_url']
+            new_annotations_region_url = new_slide['annotations_region_url']
+            new_annotations_metadata_url = new_slide['annotations_metadata_url']
+            new_metadata_url = new_slide['metadata_url']
+        else:
+            new_tile_url = new_slide['tiles_url']+f'?token={vis_data["current_user"]["token"]}'
+            new_annotations_url = new_slide['annotations_url']+f'?token={vis_data["current_user"]["token"]}'
+            new_annotations_metadata_url = new_slide['annotations_metadata_url']+f'?token={vis_data["current_user"]["token"]}'
+            new_metadata_url = new_slide['metadata_url']+f'?token={vis_data["current_user"]["token"]}'
+
+        new_metadata = requests.get(new_metadata_url).json()
+        new_annotations_metadata = requests.get(new_annotations_metadata_url).json()
+        new_tile_size = new_metadata['tileHeight']
+        x_scale, y_scale = self.get_scale_factors(new_metadata)
+
+        annotation_names = []
+        image_overlays = []
+        print(new_annotations_metadata)
+        initial_anns = []
+        for a in new_annotations_metadata:
+            if 'annotation' in a:
+                annotation_names.append(a['annotation']['name'])
+                initial_anns.append({
+                    'type': 'FeatureCollection', 
+                    'properties': {'name': a['annotation']['name'], '_id': a['_id']},
+                    'features': []
+                    })
+            elif 'name' in a:
+                annotation_names.append(a['name'])
+                initial_anns.append({
+                    'type': 'FeatureCollection',
+                    'properties': {'name': a['name'],'_id': a['_id']},
+                    'features': []
+                })
+            elif 'image_path' in a:
+                image_overlays.append(a)
+
+        print(annotation_names)
+
+        # Creating annotation layers
+        new_layer_children = []
+        for ann_idx, ann in enumerate(annotation_names):
+            new_layer_children.append(
+                dl.Overlay(
+                    dl.LayerGroup(
+                        dl.GeoJSON(
+                            data = {
+                                "type": "FeatureCollection",
+                                "features": []
+                            },
+                            format = 'geojson',
+                            id = {'type': f'{self.component_prefix}-feature-bounds','index': ann_idx},
+                            options = {
+                                'style': self.js_namespace("featureStyle")
+                            },
+                            filter = self.js_namespace("featureFilter"),
+                            hideout = {
+                                'overlayBounds': {},
+                                'overlayProp': {},
+                                'fillOpacity': 0.5,
+                                'lineColor': {
+                                    k: '#%02x%02x%02x' % (np.random.randint(0,255),np.random.randint(0,255),np.random.randint(0,255))
+                                    for k in annotation_names
+                                },
+                                'filterVals': [],
+                                'colorMap': 'blue->red'
+                            },
+                            hoverStyle = arrow_function(
+                                {
+                                    'weight': 5,
+                                    'color': '#9caf00',
+                                    'dashArray':''
+                                }
+                            ),
+                            zoomToBounds = False,
+                            children = [
+                                dl.Popup(
+                                    id = {'type': f'{self.component_prefix}-feature-popup','index': ann_idx},
+                                    autoPan = False,
+                                )
+                            ]
+                        )
+                    ),
+                    name = ann, checked = True, id = {'type':f'{self.component_prefix}-feature-overlay','index':np.random.randint(0,1000)}
+                )
+            )
+
+        # Adding image annotations
+        #TODO: Make these region specific
+        for img_idx, img in enumerate(image_overlays):
+
+            # miny, minx, maxy, maxx (a.k.a. minlat, minlng, maxlat, maxlng)
+            scaled_image_bounds = [
+                [img['image_bounds'][1]*y_scale,
+                 img['image_bounds'][0]*x_scale],
+                [img['image_bounds'][3]*y_scale,
+                 img['image_bounds'][2]*x_scale]
+            ]
+            # Creating data: path for image
+            with open(img['image_path'],'rb') as f:
+                new_image_path = f'data:image/{img["image_path"].split(".")[-1]};base64,{base64.b64encode(f.read()).decode("ascii")}'
+                f.close()
+
+            image_overlay_popup = self.get_image_overlay_popup(img, img_idx)
+
+            new_layer_children.extend([
+                dl.ImageOverlay(
+                    url = new_image_path,
+                    opacity = 0.5,
+                    interactive = True,
+                    bounds = scaled_image_bounds,
+                    id = {'type': f'{self.component_prefix}-image-overlay','index': img_idx},
+                    children = [
+                        image_overlay_popup
+                    ]
+                ),
+                dl.LayerGroup(
+                    id = {'type': f'{self.component_prefix}-image-overlay-mover-layergroup','index': img_idx},
+                    children = []
+                )
+            ])
+
+        # For MultiFrameSlideMap, add frame BaseLayers and RGB layer (if present)
+        if isinstance(self,MultiFrameSlideMap):
+            new_layer_children.extend(self.process_frames(new_metadata, new_tile_url))
+            new_tile_layer = dl.TileLayer(
+                id = {'type': f'{self.component_prefix}-map-tile-layer','index': np.random.randint(0,1000)},
+                url = '',                
+                tileSize=new_tile_size,
+                maxNativeZoom=new_metadata['levels']-2,
+                minZoom = 0
+            )
+        else:
+            new_tile_layer = dl.TileLayer(
+                id = {'type': f'{self.component_prefix}-map-tile-layer','index': np.random.randint(0,1000)},
+                url = new_tile_url,
+                tileSize = new_tile_size,
+                maxNativeZoom=new_metadata['levels']-2,
+                minZoom = 0
+            )
+
+        new_slide_info = {}
+        new_slide_info['x_scale'] = x_scale
+        new_slide_info['y_scale'] = y_scale
+        new_slide_info['image_overlays'] = image_overlays
+        new_slide_info['slide_info'] = new_slide
+        new_slide_info['tiles_url'] = new_tile_url
+        new_slide_info['annotations_url'] = new_annotations_url
+        new_slide_info['annotations_region_url'] = new_annotations_region_url
+        new_slide_info['annotations_metadata'] = new_annotations_metadata
+        new_slide_info['minZoom'] = self.min_zoom
+
+        geo_annotations = json.dumps(initial_anns)
+        new_slide_info = json.dumps(new_slide_info)
+
+        # Updating manual and generated ROIs divs
+        manual_rois = []
+        gen_rois = []
+
+        return new_layer_children, manual_rois, gen_rois, geo_annotations, new_tile_layer, new_slide_info
+
     
+
 
 class LargeMultiFrameSlideMap(MultiFrameSlideMap):
     """This is a sub-class of MultiFrameSlideMap used for LARGE amounts of annotations (>50k)
@@ -1626,7 +2259,11 @@ class LargeMultiFrameSlideMap(MultiFrameSlideMap):
 
     def update_layout(self, session_data:dict, use_prefix:bool):
         pass
-    
+
+    def gen_layout(self, session_data: dict):
+
+        self.blueprint.layout = self.update_layout(session_data, use_prefix = False)
+
 
 
 
@@ -1640,6 +2277,7 @@ class SlideImageOverlay(MapComponent):
     def __init__(self,
                  image_path: str,
                  image_crs: list = [0,0],
+                 name: Union[str,None] = None,
                  image_properties: Union[dict,None] = {"None": ""}
                 ):
         """Constructor method
@@ -1654,8 +2292,13 @@ class SlideImageOverlay(MapComponent):
         self.image_path = image_path
         self.image_crs = image_crs
         self.image_properties = image_properties
+        if name is None:
+            self.name = self.image_path.split(os.sep)[-1]
+        else:
+            self.name = name
 
         self.image_bounds = self.get_image_bounds()
+        self._id = uuid.uuid4().hex[:24]
 
     def get_image_bounds(self):
         """Get total bounds of image overlay in original CRS (number of pixels)
@@ -1670,10 +2313,16 @@ class SlideImageOverlay(MapComponent):
         return self.image_crs + [self.image_crs[0]+image_shape[1], self.image_crs[1]+image_shape[0]]
 
     def to_dict(self):
-        return {'image_path': self.image_path, 'image_crs': self.image_crs, 'image_properties': self.image_properties,'image_bounds': self.image_bounds}
+        overlay_info_dict = {
+            'image_path': self.image_path,
+            'image_crs': self.image_crs,
+            'image_properties': self.image_properties,
+            'image_bounds': self.image_bounds,
+            'name': self.name,
+            '_id': self._id
+        }
 
-
-
+        return overlay_info_dict
 
 class ChannelMixer(MapComponent):
     """ChannelMixer component that allows users to select various frames from their image to overlay at the same time with different color (styles) applied.

--- a/src/fusion_tools/components/segmentation.py
+++ b/src/fusion_tools/components/segmentation.py
@@ -974,8 +974,6 @@ class BulkLabels(Tool):
             name = 'removeMarker',
             src = """
                 function(e,ctx){
-                    console.log(ctx);
-                    console.log(e);
                     e.target.removeLayer(e.layer._leaflet_id);
                     ctx.data.features.splice(ctx.data.features.indexOf(e.layer.feature),1);
                 }

--- a/src/fusion_tools/components/segmentation.py
+++ b/src/fusion_tools/components/segmentation.py
@@ -2299,8 +2299,7 @@ class BulkLabels(Tool):
             if len(id_intersect)>0:
                 for id in id_intersect:
                     feature_label = current_labels['labels'][label_ids.index(id)]
-                    #print(feature_label)
-                    c['features'][feature_ids.index(id)]['properties'] = c['features'][feature_ids.index(id)]['properties'] | current_labels['labels'][label_ids.index(id)]
+                    c['features'][feature_ids.index(id)]['properties'] = c['features'][feature_ids.index(id)]['properties'] | feature_label
 
         updated_annotations = json.dumps(current_annotations)
 

--- a/src/fusion_tools/components/tools.py
+++ b/src/fusion_tools/components/tools.py
@@ -483,7 +483,7 @@ class OverlayOptions(Tool):
         )(self.export_layers)
 
     def update_slide(self, new_annotations:list):
-
+        
         if not any([i['value'] for i in ctx.triggered]):
             raise exceptions.PreventUpdate
 
@@ -1016,7 +1016,6 @@ class OverlayOptions(Tool):
         if not any([i['value'] for i in ctx.triggered]):
             raise exceptions.PreventUpdate
         
-        #TODO: Re-scale these so that the annotations are in the image CRS
         slide_information = json.loads(get_pattern_matching_value(slide_information))
 
         # Scaling annotations:

--- a/src/fusion_tools/dataset.py
+++ b/src/fusion_tools/dataset.py
@@ -278,11 +278,11 @@ class SegmentationDataset:
                                 'properties': {}
                             }]
                         }
-                elif type(self.patch_regions[s_idx])==dict:
-                    available_regions = self.patch_regions[s_idx]
+                elif type(self.patch_region[s_idx])==dict:
+                    available_regions = self.patch_region[s_idx]
 
-            elif type(self.patch_regions)==dict:
-                available_regions = self.patch_regions
+            elif type(self.patch_region)==dict:
+                available_regions = self.patch_region
 
             single_slide_data['available_regions'] = available_regions
 
@@ -876,11 +876,11 @@ class ClassificationDataset:
                                 'properties': {}
                             }]
                         }
-                elif type(self.patch_regions[s_idx])==dict:
-                    available_regions = self.patch_regions[s_idx]
+                elif type(self.patch_region[s_idx])==dict:
+                    available_regions = self.patch_region[s_idx]
 
-            elif type(self.patch_regions)==dict:
-                available_regions = self.patch_regions
+            elif type(self.patch_region)==dict:
+                available_regions = self.patch_region
 
             single_slide_data['available_regions'] = available_regions
 

--- a/src/fusion_tools/visualization/components.py
+++ b/src/fusion_tools/visualization/components.py
@@ -126,6 +126,7 @@ class Visualization:
             ],
             'external_scripts': [
                 'https://cdnjs.cloudflare.com/ajax/libs/chroma-js/2.1.0/chroma.min.js',
+                "https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js"
             ]
         }
 
@@ -326,7 +327,9 @@ class Visualization:
                         'tiles_url': self.local_tile_server.get_name_tiles_url(s.split(os.sep)[-1]),
                         'regions_url': self.local_tile_server.get_name_regions_url(s.split(os.sep)[-1]),
                         'metadata_url': self.local_tile_server.get_name_metadata_url(s.split(os.sep)[-1]),
-                        'annotations_url': self.local_tile_server.get_name_annotations_url(s.split(os.sep)[-1])
+                        'annotations_url': self.local_tile_server.get_name_annotations_url(s.split(os.sep)[-1]),
+                        'annotations_metadata_url': self.local_tile_server.get_name_annotations_metadata_url(s.split(os.sep)[-1]),
+                        'annotations_region_url': self.local_tile_server.get_name_annotations_url(s.split(os.sep)[-1])
                     }
 
                 slide_store['current'].append(slide_dict)
@@ -349,7 +352,9 @@ class Visualization:
                             'tiles_url': t.get_name_tiles_url(j),
                             'regions_url': t.get_name_regions_url(j),
                             'metadata_url': t.get_name_metadata_url(j),
-                            'annotations_url': t.get_name_annotations_url(j)
+                            'annotations_url': t.get_name_annotations_url(j),
+                            'annotations_metadata_url': t.get_name_annotations_metadata_url(j),
+                            'annotations_region_url': t.get_name_annotations_url(j)
                         }
                         for j in t['names']
                     ])
@@ -360,7 +365,9 @@ class Visualization:
                             'tiles_url': t.get_name_tiles_url(j),
                             'regions_url': t.get_name_regions_url(j),
                             'metadata_url': t.get_name_metadata_url(j),
-                            'annotations_url': t.get_name_annotations_url(j)
+                            'annotations_url': t.get_name_annotations_url(j),
+                            'annotations_metadata_url': t.get_name_annotations_metadata_url(j),
+                            'annotations_region_url': t.get_name_annotations_url(j)
                         }
                         for j in t['names']
                     ])
@@ -373,7 +380,9 @@ class Visualization:
                         'tiles_url': t.tiles_url,
                         'regions_url': t.regions_url,
                         'metadata_url': t.metadata_url,
-                        'annotations_url': t.annotations_url
+                        'annotations_url': t.annotations_url,
+                        'annotations_metadata_url':t.annotations_metadata_url,
+                        'annotations_region_url': t.annotations_region_url
                     })
                 elif type(t)==CustomTileServer:
                     slide_store['current'].append({
@@ -382,7 +391,9 @@ class Visualization:
                         'tiles_url': t.tiles_url,
                         'regions_url': t.regions_url if hasattr(t,'regions_url') else None,
                         'metadata_url': t.metadata_url if hasattr(t,'metadata_url') else None,
-                        'annotations_url': t.annotations_url if hasattr(t,'annotations_url') else None
+                        'annotations_url': t.annotations_url if hasattr(t,'annotations_url') else None,
+                        'annotations_metadata_url': t.annotations_metadata_url if hasattr(t,'annotations_metadata_url') else None,
+                        'annotations_region_url': t.annotations_regions_url if hasattr(t,'annotations_regions_url') else None
                     })
 
 

--- a/tests/test_large_slide_maps.py
+++ b/tests/test_large_slide_maps.py
@@ -1,0 +1,78 @@
+"""Testing out LargeSlideMap components
+"""
+
+import os
+import sys
+sys.path.append('./src/')
+import json
+import requests
+
+from fusion_tools.handler.dsa_handler import DSAHandler
+from fusion_tools import Visualization
+from fusion_tools.components.maps import LargeSlideMap, SlideMap
+from fusion_tools.components import OverlayOptions
+
+
+
+def main():
+
+    # Grabbing first item from demo DSA instance
+    base_url = 'http://ec2-3-230-122-132.compute-1.amazonaws.com:8080/api/v1'
+    item_id = '64f545302d82d04be3e39eec'
+
+    # Starting the DSAHandler to grab information:
+    dsa_handler = DSAHandler(
+        girderApiUrl = base_url
+    )
+
+    dsa_tileserver = [
+        dsa_handler.get_tile_server(item_id)
+    ]
+    
+    base_dir = 'C:\\Users\\samuelborder\\Desktop\\HIVE_Stuff\\FUSION\\Test Upload\\'
+    local_slide_list = [
+        base_dir+'XY01_IU-21-015F_001.svs'
+    ]
+    local_annotations_list = [
+        base_dir+'XY01_IU-21-015F_001.xml'
+    ]
+
+    vis_session = Visualization(
+        local_slides = local_slide_list,
+        local_annotations = local_annotations_list,
+        tileservers = dsa_tileserver,
+        components = [
+            [
+                SlideMap(
+                #    min_zoom = 4
+                ),
+                [
+                    OverlayOptions()
+                ]
+            ]
+        ]
+    )
+
+    vis_session.start()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+if __name__=='__main__':
+    main()

--- a/tests/test_large_slide_maps.py
+++ b/tests/test_large_slide_maps.py
@@ -43,8 +43,8 @@ def main():
         tileservers = dsa_tileserver,
         components = [
             [
-                SlideMap(
-                #    min_zoom = 4
+                LargeSlideMap(
+                    min_zoom = 4
                 ),
                 [
                     OverlayOptions()


### PR DESCRIPTION
This PR includes two new components, LargeSlideMap and LargeMultiFrameSlideMap.

The difference between these components and their counterparts is simple, the large ones are for slides that have a large number of annotations which would be a drain on performance to download and render on the frontend. By setting a minimum zoom value for each of these components, only the annotations within the current viewport beyond that minimum zoom value  are grabbed from either a cloud server or a local store of annotations. Users are still able to filter and display overlaid colors on these annotations, although other components which specifically reference the "map-annotations-store" component will only be able to access the currently rendered annotations. 

Correcting for this in components like the PropertyPlotter, BulkLabels, and GlobalPropertyPlotter should be the subject a future PR.