### PR TITLE
Updated slide map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 <!--next-version-placeholder-->
+## v3.4.0 (03/2025)
+
+### Features:
+- `DataExtractor` component added!
+    - This component enables many different types of data extraction including properties, annotations, images, and masks from individual slides as well as session data (slide metadata and visualization session data)
+- Saving sessions!
+    - Using the `DataExtractor` component, you can now save your current visualization session and then upload it in the `DatasetBuilder` component to quickly reload.
+    - In successive versions, more information from user interactions can be stored in this session and reloaded whenever someone wants to use a previous session.
+        - Things like:
+            1. Manual ROIs per-slide
+            2. Marked structures per-slide
+            3. Labeling sessions (`BulkLabels`)
+
 ## v3.1.0 (02/2025)
 
 ### Features:

--- a/docs/source/components_overview.rst
+++ b/docs/source/components_overview.rst
@@ -129,6 +129,18 @@ BulkLabels
    :members:
 
 
+Download Components
+-------------------
+
+DataExtractor
+^^^^^^^^^^^^^
+
+.. raw:: html
+   <iframe width="560" height="315" src="https://www.youtube.com/embed/jlLkwKMvHiQ?si=0KkiGyhn0jH_BTIq" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+.. autoclass:: fusion_tools.components::DataExtractor
+   :members:
+   
 
 Digital Slide Archive (DSA) Integrated Components
 -------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="fusion-tools",
-    version="3.5.1",
+    version="3.5.2",
     author="Sam Border",
     author_email="sam.border2256@gmail.com",
     description="Modular visualization and analysis dashboard creation for high-resolution microscopy images",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="fusion-tools",
-    version="3.3.15",
+    version="3.4.2",
     author="Sam Border",
     author_email="sam.border2256@gmail.com",
     description="Modular visualization and analysis dashboard creation for high-resolution microscopy images",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="fusion-tools",
-    version="3.4.2",
+    version="3.5.0",
     author="Sam Border",
     author_email="sam.border2256@gmail.com",
     description="Modular visualization and analysis dashboard creation for high-resolution microscopy images",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="fusion-tools",
-    version="3.5.0",
+    version="3.5.1",
     author="Sam Border",
     author_email="sam.border2256@gmail.com",
     description="Modular visualization and analysis dashboard creation for high-resolution microscopy images",

--- a/src/fusion_tools.egg-info/PKG-INFO
+++ b/src/fusion_tools.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.2
 Name: fusion-tools
-Version: 3.3.15
+Version: 3.4.2
 Summary: Modular visualization and analysis dashboard creation for high-resolution microscopy images
 Home-page: https://github.com/spborder/fusion-tools
 Author: Sam Border

--- a/src/fusion_tools.egg-info/PKG-INFO
+++ b/src/fusion_tools.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.2
 Name: fusion-tools
-Version: 3.5.0
+Version: 3.5.1
 Summary: Modular visualization and analysis dashboard creation for high-resolution microscopy images
 Home-page: https://github.com/spborder/fusion-tools
 Author: Sam Border

--- a/src/fusion_tools.egg-info/PKG-INFO
+++ b/src/fusion_tools.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.2
 Name: fusion-tools
-Version: 3.4.2
+Version: 3.5.0
 Summary: Modular visualization and analysis dashboard creation for high-resolution microscopy images
 Home-page: https://github.com/spborder/fusion-tools
 Author: Sam Border

--- a/src/fusion_tools.egg-info/PKG-INFO
+++ b/src/fusion_tools.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.2
 Name: fusion-tools
-Version: 3.5.1
+Version: 3.5.2
 Summary: Modular visualization and analysis dashboard creation for high-resolution microscopy images
 Home-page: https://github.com/spborder/fusion-tools
 Author: Sam Border

--- a/src/fusion_tools.egg-info/SOURCES.txt
+++ b/src/fusion_tools.egg-info/SOURCES.txt
@@ -53,6 +53,7 @@ tests/test_get_gene_info.py
 tests/test_global_property_plotter.py
 tests/test_hra_viewer.py
 tests/test_image_overlay.py
+tests/test_json_stream.py
 tests/test_large_slide_maps.py
 tests/test_load_visium_csv.py
 tests/test_meta_embed.py

--- a/src/fusion_tools.egg-info/SOURCES.txt
+++ b/src/fusion_tools.egg-info/SOURCES.txt
@@ -46,6 +46,7 @@ tests/test_extract_recursive.py
 tests/test_feature_annotation.py
 tests/test_feature_extraction.py
 tests/test_file_selector.py
+tests/test_format_intersecting_masks.py
 tests/test_fusion_layout.py
 tests/test_generate_property_dict.py
 tests/test_get_gene_info.py

--- a/src/fusion_tools/components/maps.py
+++ b/src/fusion_tools/components/maps.py
@@ -647,6 +647,15 @@ class SlideMap(MapComponent):
                 // Reading in map-slide-information
                 var map_slide_information = JSON.parse(slide_information);
 
+                function uuidv4() {
+                    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
+                    .replace(/[xy]/g, function (c) {
+                        const r = Math.random() * 16 | 0, 
+                            v = c == 'x' ? r : (r & 0x3 | 0x8);
+                        return v.toString(16);
+                    });
+                }
+
                 // Annotations have to be in GeoJSON format already in order to use this
                 function process_json(json_data, idx, ann_meta){
                     if (json_data.constructor.name == 'Object'){
@@ -667,7 +676,7 @@ class SlideMap(MapComponent):
                             name: name,
                             _id: id
                         },
-                        features: data.features.map(feature => ({
+                        features: data.features.map((feature,f_idx) => ({
                             ...feature,
                             geometry: {
                                 ...feature.geometry,
@@ -678,6 +687,8 @@ class SlideMap(MapComponent):
                             properties: {
                                 ...feature.properties.user,
                                 name: name,
+                                _id: uuidv4(),
+                                _index: f_idx
                             }
                         }))
                     }

--- a/src/fusion_tools/components/maps.py
+++ b/src/fusion_tools/components/maps.py
@@ -697,6 +697,9 @@ class SlideMap(MapComponent):
 
                 var ann_meta = await ann_meta_response.json();
 
+                // Making sure these are only structural annotations, not image overlays
+                ann_meta = ann_meta.filter(item => !('image_path' in item))
+
                 if (ann_meta.length==0){
                     let empty_geojson = {
                         'type': 'FeatureCollection',
@@ -707,6 +710,7 @@ class SlideMap(MapComponent):
                     return [[empty_geojson], [JSON.stringify([empty_geojson])]]
                 }
 
+                // Initializing empty annotations list
                 var annotations_list = new Array(ann_meta.length);
                 try {
                     if ('annotations_geojson_url' in map_slide_information){
@@ -811,11 +815,14 @@ class SlideMap(MapComponent):
         new_tile_size = new_image_metadata['tileHeight']
 
         image_overlay_annotations = [i for i in annotations_metadata if 'image_path' in i]
+        print(image_overlay_annotations)
+        non_image_overlay_metadata = [i for i in annotations_metadata if not 'image_path' in i]
         x_scale, y_scale = self.get_scale_factors(new_image_metadata)
         new_layer_children = []
 
         # Adding overlaid annotation layers:
-        for st_idx, st_info in enumerate(annotations_metadata):
+        for st_idx, st_info in enumerate(non_image_overlay_metadata):
+
             new_layer_children.append(
                 dl.Overlay(
                     dl.LayerGroup(

--- a/src/fusion_tools/components/segmentation.py
+++ b/src/fusion_tools/components/segmentation.py
@@ -436,7 +436,7 @@ class FeatureAnnotation(Tool):
         slide_data = vis_data['current'][get_pattern_matching_value(slide_selection)]
         new_slide_data = {}
         new_slide_data['regions_url'] = slide_data['regions_url']
-        new_metadata = requests.get(slide_data['metadata_url']).json()
+        new_metadata = requests.get(slide_data['image_metadata_url']).json()
         new_slide_data['x_scale'], new_slide_data['y_scale'] = self.get_scale_factors(new_metadata)
 
         new_slide_data = json.dumps(new_slide_data)

--- a/src/fusion_tools/components/segmentation.py
+++ b/src/fusion_tools/components/segmentation.py
@@ -1870,7 +1870,6 @@ class BulkLabels(Tool):
 
         filter_data = json.loads(get_pattern_matching_value(filter_data))
 
-        #TODO: Add the mods to this function
         filtered_geojson, filtered_ref_list = process_filters_queries(filter_data["Filters"], filter_data["Spatial"], include_structures, current_features)
 
         new_structures_div = [

--- a/src/fusion_tools/tileserver.py
+++ b/src/fusion_tools/tileserver.py
@@ -86,11 +86,14 @@ class LocalTileServer(TileServer):
 
     def extract_meta_dict(self, annotations):
 
-        if type(annotations)==dict:
+        if not type(annotations)==list:
             annotations = [annotations]
 
         ann_metadata = []
         for a in annotations:
+            if hasattr(a,'to_dict'):
+                a = a.to_dict()
+                
             if 'properties' in a:
                 ann_metadata.append({
                     'name': a['properties']['name'],

--- a/src/fusion_tools/utils/images.py
+++ b/src/fusion_tools/utils/images.py
@@ -440,38 +440,3 @@ def format_intersecting_masks(base_geojson, other_geojsons, mask_format='one-hot
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/fusion_tools/utils/shapes.py
+++ b/src/fusion_tools/utils/shapes.py
@@ -1278,7 +1278,6 @@ def process_filters_queries(filter_list:list, spatial_list:list, structures:list
 
             # only used for OR mods
             include_list = [(False,)]*intermediate_gdf.shape[0]
-            print(len(include_list))
             for s_q in spatial_list:
                 sq_geo = [i for i in all_geo_list if i['properties']['name']==s_q['structure']][0]
                 sq_structure = gpd.GeoDataFrame.from_features(sq_geo['features'])

--- a/src/fusion_tools/utils/shapes.py
+++ b/src/fusion_tools/utils/shapes.py
@@ -1278,7 +1278,7 @@ def process_filters_queries(filter_list:list, spatial_list:list, structures:list
 
             # only used for OR mods
             include_list = [(False,)]*intermediate_gdf.shape[0]
-
+            print(len(include_list))
             for s_q in spatial_list:
                 sq_geo = [i for i in all_geo_list if i['properties']['name']==s_q['structure']][0]
                 sq_structure = gpd.GeoDataFrame.from_features(sq_geo['features'])
@@ -1294,13 +1294,9 @@ def process_filters_queries(filter_list:list, spatial_list:list, structures:list
                             )
 
                             # Updating include_list (removing items)
-                            del_count = 0
-                            for idx,i in enumerate(intermediate_gdf['_id_right'].isna().tolist()):
-                                if not i:
-                                    del include_list[idx-del_count]
-                                    del_count+=1
-                                else:
-                                    include_list[idx-del_count]+=(True,)
+                            include_list = [i for d,i in zip(intermediate_gdf['_id_right'].isna().tolist(),include_list) if not d]
+                            include_list = [i+(True,) for i in include_list]
+
 
                             intermediate_gdf = intermediate_gdf.loc[intermediate_gdf['_id_right'].isna()]
                             
@@ -1312,13 +1308,8 @@ def process_filters_queries(filter_list:list, spatial_list:list, structures:list
                                 predicate = s_q['type']
                             )
                             # Updating include_list (removing items)
-                            del_count = 0
-                            for idx,i in enumerate(intermediate_gdf['_id_right'].isna().tolist()):
-                                if i:
-                                    del include_list[idx-del_count]
-                                    del_count+=1
-                                else:
-                                    include_list[idx-del_count]+=(True,)
+                            include_list = [i for d,i in zip(intermediate_gdf['_id_right'].isna().tolist(),include_list) if not d]
+                            include_list = [i+(True,) for i in include_list]
 
                             intermediate_gdf = intermediate_gdf.loc[intermediate_gdf['_id_right'].notna()]
                             
@@ -1341,13 +1332,8 @@ def process_filters_queries(filter_list:list, spatial_list:list, structures:list
                         )
 
                         # Updating include_list (removing items)
-                        del_count = 0
-                        for idx,i in enumerate(intermediate_gdf['_id_right'].isna().tolist()):
-                            if i:
-                                del include_list[idx-del_count]
-                                del_count+=1
-                            else:
-                                include_list[idx-del_count]+=(True,)
+                        include_list = [i for d,i in zip(intermediate_gdf['_id_right'].isna().tolist(),include_list) if not d]
+                        include_list = [i+(True,) for i in include_list]
 
                         intermediate_gdf = intermediate_gdf.loc[intermediate_gdf['_id_right'].notna()]
 
@@ -1362,13 +1348,9 @@ def process_filters_queries(filter_list:list, spatial_list:list, structures:list
                             )
 
                             # Updating include_list (removing items)
-                            del_count = 0
-                            for idx,i in enumerate(intermediate_gdf['_id_right'].isna().tolist()):
-                                if not i:
-                                    del include_list[idx-del_count]
-                                    del_count+=1
-                                else:
-                                    include_list[idx-del_count]+=(True,)
+                            include_list = [i for d,i in zip(intermediate_gdf['_id_right'].isna().tolist(),include_list) if not d]
+                            include_list = [i+(True,) for i in include_list]
+
 
                             intermediate_gdf = intermediate_gdf.loc[intermediate_gdf['_id_right'].isna()]
 
@@ -1381,13 +1363,8 @@ def process_filters_queries(filter_list:list, spatial_list:list, structures:list
                             )
 
                             # Updating include_list (removing items)
-                            del_count = 0
-                            for idx,i in enumerate(intermediate_gdf['_id_right'].isna().tolist()):
-                                if i:
-                                    del include_list[idx-del_count]
-                                    del_count+=1
-                                else:
-                                    include_list[idx-del_count]+=(True,)
+                            include_list = [i for d,i in zip(intermediate_gdf['_id_right'].isna().tolist(),include_list) if not d]
+                            include_list = [i+(True,) for i in include_list]
 
                             intermediate_gdf = intermediate_gdf.loc[intermediate_gdf['_id_right'].notna()]
                         
@@ -1412,13 +1389,9 @@ def process_filters_queries(filter_list:list, spatial_list:list, structures:list
                         )
 
                         # Updating include_list (removing items)
-                        del_count = 0
-                        for idx,i in enumerate(intermediate_gdf['_id_right'].isna().tolist()):
-                            if i:
-                                del include_list[idx-del_count]
-                                del_count+=1
-                            else:
-                                include_list[idx-del_count]+=(True,)
+                        include_list = [i for d,i in zip(intermediate_gdf['_id_right'].isna().tolist(),include_list) if not d]
+                        include_list = [i+(True,) for i in include_list]
+
 
                         intermediate_gdf = intermediate_gdf.loc[intermediate_gdf['_id_right'].notna()]
                     

--- a/src/fusion_tools/utils/shapes.py
+++ b/src/fusion_tools/utils/shapes.py
@@ -450,7 +450,10 @@ def load_visium(visium_path:str, include_var_names:list = [], include_obs: list 
                 try:
                     additional_props[i] = float(spot_coords.loc[barcodes[idx],i])
                 except ValueError:
-                    additional_props[i] = spot_coords.loc[barcodes[idx],i]
+                    if not '{' in spot_coords.loc[barcodes[idx],i]:
+                        additional_props[i] = spot_coords.loc[barcodes[idx],i]
+                    else:
+                        additional_props[i] = json.loads(spot_coords.loc[barcodes[idx],i].replace("'",'"'))
         
         for j in include_obs:
             if not anndata_object is None:
@@ -458,10 +461,14 @@ def load_visium(visium_path:str, include_var_names:list = [], include_obs: list 
             else:
                 add_prop = spot_coords.loc[idx,j].values
 
-            if not type(add_prop)==str:
-                additional_props[j] = float(add_prop)
-            else:
-                additional_props[j] = add_prop
+            try:
+                additional_props[i] = float(add_prop)
+            except ValueError:
+                if not '{' in add_prop:
+                    additional_props[i] = add_prop
+                else:
+                    additional_props[i] = json.loads(add_prop.replace("'",'"'))
+
 
         spot_feature = {
             'type': 'Feature',

--- a/src/fusion_tools/utils/shapes.py
+++ b/src/fusion_tools/utils/shapes.py
@@ -1131,10 +1131,18 @@ def extract_geojson_properties(geo_list: list, reference_object: Union[str,None]
     if ignore_list is None:
         ignore_list = []
 
+    if type(geo_list)==dict:
+        geo_list = [geo_list]
+
+    start = time.time()
     geojson_properties = []
     feature_names = []
     property_info = {}
     for ann in geo_list:
+        if not 'properties' in ann:
+            continue
+        if len(list(ann['properties'].keys()))==0:
+            continue
         feature_names.append(ann['properties']['name'])
         for f in ann['features']:
             f_props = [i for i in list(f['properties'].keys()) if not i in ignore_list]
@@ -1218,6 +1226,7 @@ def extract_geojson_properties(geo_list: list, reference_object: Union[str,None]
     
     
     geojson_properties = sorted(geojson_properties)
+    end = time.time()
 
     return geojson_properties, feature_names, property_info
 

--- a/src/fusion_tools/visualization/components.py
+++ b/src/fusion_tools/visualization/components.py
@@ -324,10 +324,10 @@ class Visualization:
                     )
 
                     slide_dict = {
-                        #'start_idx': s_idx,
                         'name': s.split(os.sep)[-1],
                         'tiles_url': self.local_tile_server.get_name_tiles_url(s.split(os.sep)[-1]),
                         'regions_url': self.local_tile_server.get_name_regions_url(s.split(os.sep)[-1]),
+                        'image_metadata_url': self.local_tile_server.get_name_image_metadata_url(s.split(os.sep)[-1]),
                         'metadata_url': self.local_tile_server.get_name_metadata_url(s.split(os.sep)[-1]),
                         'annotations_url': self.local_tile_server.get_name_annotations_url(s.split(os.sep)[-1]),
                         'annotations_metadata_url': self.local_tile_server.get_name_annotations_metadata_url(s.split(os.sep)[-1]),
@@ -349,10 +349,10 @@ class Visualization:
                 if type(t)==LocalTileServer:
                     slide_store['current'].extend([
                         {
-                            #'start_idx': (s_idx+t_idx+1),
                             'name': j,
                             'tiles_url': t.get_name_tiles_url(j),
                             'regions_url': t.get_name_regions_url(j),
+                            'image_metadata_url': t.get_name_image_metadata_url(j),
                             'metadata_url': t.get_name_metadata_url(j),
                             'annotations_url': t.get_name_annotations_url(j),
                             'annotations_metadata_url': t.get_name_annotations_metadata_url(j),
@@ -362,10 +362,10 @@ class Visualization:
                     ])
                     slide_store['local'].extend([
                         {
-                            #'start_idx': (s_idx+t_idx+1),
                             'name': j,
                             'tiles_url': t.get_name_tiles_url(j),
                             'regions_url': t.get_name_regions_url(j),
+                            'image_metadata_url': t.get_name_image_metadata_url(j),
                             'metadata_url': t.get_name_metadata_url(j),
                             'annotations_url': t.get_name_annotations_url(j),
                             'annotations_metadata_url': t.get_name_annotations_metadata_url(j),
@@ -376,26 +376,28 @@ class Visualization:
 
                 elif type(t)==DSATileServer:
                     slide_store['current'].append({
-                        #'start_idx': (s_idx+t_idx+1),
                         'name': t.name,
                         'api_url': t.base_url,
                         'tiles_url': t.tiles_url,
                         'regions_url': t.regions_url,
+                        'image_metadata_url': t.image_metadata_url,
                         'metadata_url': t.metadata_url,
                         'annotations_url': t.annotations_url,
                         'annotations_metadata_url':t.annotations_metadata_url,
-                        'annotations_region_url': t.annotations_region_url
+                        'annotations_region_url': t.annotations_region_url,
+                        'annotations_geojson_url': t.annotations_geojson_url
                     })
                 elif type(t)==CustomTileServer:
                     slide_store['current'].append({
-                        #'start_idx': (s_idx+t_idx+t),
                         'name': t.name,
                         'tiles_url': t.tiles_url,
                         'regions_url': t.regions_url if hasattr(t,'regions_url') else None,
+                        'image_metadata_url': t.image_metadata_url if hasattr(t,'image_metadata_url') else None,
                         'metadata_url': t.metadata_url if hasattr(t,'metadata_url') else None,
                         'annotations_url': t.annotations_url if hasattr(t,'annotations_url') else None,
                         'annotations_metadata_url': t.annotations_metadata_url if hasattr(t,'annotations_metadata_url') else None,
-                        'annotations_region_url': t.annotations_regions_url if hasattr(t,'annotations_regions_url') else None
+                        'annotations_region_url': t.annotations_regions_url if hasattr(t,'annotations_regions_url') else None,
+                        'annotations_geojson_url': t.annotations_geojson_url if hasattr(t,'annotations_geojson_url') else None
                     })
 
 

--- a/tests/test_dsa_components.py
+++ b/tests/test_dsa_components.py
@@ -232,7 +232,7 @@ def main():
     ]
 
     # This can be set to False or removed, testing the upload overlaid annotations
-    testing_upload = True
+    testing_upload = False
     local_annotations_list = [
         base_dir+'XY01_IU-21-015F_001.xml' if not testing_upload else None,
         None,

--- a/tests/test_image_overlay.py
+++ b/tests/test_image_overlay.py
@@ -5,22 +5,26 @@ import os
 import sys
 import threading
 sys.path.append('./src/')
-from fusion_tools import Visualization
+from fusion_tools.visualization import Visualization
 from fusion_tools.components import SlideMap, SlideImageOverlay
 
 
 def main():
 
-    slide_list = ['C:\\Users\\samuelborder\\Downloads\\10H_LargeGlobalFlatfield.tifStitchedO.svs']
+    base_dir = 'C:\\Users\\samuelborder\\Desktop\\HIVE_Stuff\\FUSION\\Test Upload\\'
+    local_slide_list = [
+        base_dir+'XY01_IU-21-015F.svs',
+    ]
+
 
     annotations = [
         SlideImageOverlay(
-            image_path = 'C:\\Users\\samuelborder\\Downloads\\10H_LargeGlobalFlatfield.tif Y00003 X00008.jpg'
+            image_path = 'C:\\Users\\samuelborder\\Downloads\\20250224_095335.jpg'
         )
     ]
     
     vis_session = Visualization(
-        local_slides = slide_list,
+        local_slides = local_slide_list,
         local_annotations=annotations,
         components = [
             [

--- a/tests/test_json_stream.py
+++ b/tests/test_json_stream.py
@@ -1,0 +1,45 @@
+"""Testing whether there is a performance difference streaming large JSON requests
+"""
+import os
+import json
+import requests
+
+import time
+
+
+
+
+def main():
+
+    item_id = '6495a4e03e6ae3107da10dc5'
+    data_url = os.environ.get('DSA_URL')+f'annotation/item/{item_id}'
+
+    start = time.time()
+    data = requests.get(data_url).json()
+    end = time.time()
+    print(f'Regular method: {end-start}')
+
+    start = time.time()
+    with requests.get(data_url,stream=True) as r:
+        r.raise_for_status()
+
+        json_data = ''
+        chunk_count = 0
+        for chunk in r.iter_content(chunk_size=8192*2):
+            json_data+=chunk.decode('utf-8')
+            chunk_count +=1
+
+        r.close()
+    print(f'Chunk count: {chunk_count}')    
+    data = json.loads(json_data)
+    end = time.time()
+
+    print(f'With streaming: {end-start}')
+
+
+
+
+
+
+if __name__=='__main__':
+    main()

--- a/tests/test_property_plotter.py
+++ b/tests/test_property_plotter.py
@@ -11,7 +11,8 @@ def main():
 
     # Grabbing first item from demo DSA instance
     base_url = 'http://ec2-3-230-122-132.compute-1.amazonaws.com:8080/api/v1'
-    item_id = '67ae1826fcdeba1e292f7057'
+    #item_id = '67ae1826fcdeba1e292f7057'
+    item_id = '6495a4e03e6ae3107da10dc5'
 
     # Starting the DSAHandler to grab information:
     dsa_handler = DSAHandler(
@@ -22,7 +23,8 @@ def main():
         tileservers = [dsa_handler.get_tile_server(item_id)],
         components = [
             [
-                LargeSlideMap(min_zoom=5),
+                #LargeSlideMap(min_zoom=5),
+                SlideMap(),
                 [
                     OverlayOptions(),
                     PropertyPlotter(),

--- a/tests/test_property_plotter.py
+++ b/tests/test_property_plotter.py
@@ -11,8 +11,7 @@ def main():
 
     # Grabbing first item from demo DSA instance
     base_url = 'http://ec2-3-230-122-132.compute-1.amazonaws.com:8080/api/v1'
-    #item_id = '67ae1826fcdeba1e292f7057'
-    item_id = '6495a4e03e6ae3107da10dc5'
+    item_id = '67ae1826fcdeba1e292f7057'
 
     # Starting the DSAHandler to grab information:
     dsa_handler = DSAHandler(
@@ -23,7 +22,6 @@ def main():
         tileservers = [dsa_handler.get_tile_server(item_id)],
         components = [
             [
-                #LargeSlideMap(min_zoom=5),
                 SlideMap(),
                 [
                     OverlayOptions(),


### PR DESCRIPTION
Shifting annotation requests to a clientside callback. Greatly improves loading speed.

Added collapsible accordions underneath the SlideMap component containing image metadata (large-image metadata), and item/case-level metadata (if any is available). This makes it easy to reference any user-added metadata at upload or at any point through DSA. Eventually, if permissions are handled correctly, this component can be made to handle adding slide-level metadata from a fusion-tools dashboard.